### PR TITLE
Changed external asset links to be either http/https

### DIFF
--- a/resources/views/partials/metadata.twig
+++ b/resources/views/partials/metadata.twig
@@ -16,8 +16,8 @@
 
 <!-- Custom Fonts -->
 {{ asset_add("theme.css", "theme::font-awesome/css/font-awesome.css", ["parse"]) }}
-<link href="http://fonts.googleapis.com/css?family=Montserrat:400,700" rel="stylesheet" type="text/css">
-<link href="http://fonts.googleapis.com/css?family=Lato:400,700,400italic,700italic" rel="stylesheet" type="text/css">
+<link href="//fonts.googleapis.com/css?family=Montserrat:400,700" rel="stylesheet" type="text/css">
+<link href="//fonts.googleapis.com/css?family=Lato:400,700,400italic,700italic" rel="stylesheet" type="text/css">
 
 {{ asset_style("theme.css") }}
 

--- a/resources/views/partials/scripts.twig
+++ b/resources/views/partials/scripts.twig
@@ -14,7 +14,7 @@
 {{ asset_script("theme.js", ["min"]) }}
 
 <!-- After the theme.js assets -->
-<script src="http://cdnjs.cloudflare.com/ajax/libs/jquery-easing/1.3/jquery.easing.min.js"></script>
+<script src="//cdnjs.cloudflare.com/ajax/libs/jquery-easing/1.3/jquery.easing.min.js"></script>
 
 {% for script in asset_scripts("scripts.js") %}
     {{ script|raw }}


### PR DESCRIPTION
Updated the asset links for external CSS/JS to use links like `//fonts.googleapis.com/css?family=Montserrat:400,700` instead of `http://fonts.googleapis.com/css?family=Montserrat:400,700` so that the content loads either over http or https
